### PR TITLE
Add String Emptiness Check

### DIFF
--- a/include/tabulate/row.hpp
+++ b/include/tabulate/row.hpp
@@ -162,9 +162,10 @@ private:
     auto newlines_in_wrapped_text =
         std::count(word_wrapped_text.begin(), word_wrapped_text.end(), '\n');
     auto estimated_row_height = newlines_in_wrapped_text;
-    if (word_wrapped_text[word_wrapped_text.size() - 1] != '\n') // text doesn't end with a newline
-      estimated_row_height += 1;
-
+    
+    if (!word_wrapped_text.empty() && word_wrapped_text[word_wrapped_text.size() - 1] != '\n') // text doesn't end with a newline
+          estimated_row_height += 1;
+    
     result += estimated_row_height;
 
     result += format.padding_bottom_.value();


### PR DESCRIPTION
Fixes #22 with a simple check to see if the word_wrapped_text string is empty before subscripting it.