### PR TITLE
fix compiler warning "non-virtual-dtor"

### DIFF
--- a/include/tabulate/asciidoc_exporter.hpp
+++ b/include/tabulate/asciidoc_exporter.hpp
@@ -69,6 +69,8 @@ public:
     return ss.str();
   }
 
+  virtual ~AsciiDocExporter() {}
+
 private:
   std::string add_formatted_cell(Cell &cell) const {
     std::stringstream ss;

--- a/include/tabulate/exporter.hpp
+++ b/include/tabulate/exporter.hpp
@@ -40,6 +40,7 @@ namespace tabulate {
 class Exporter {
 public:
   virtual std::string dump(Table &table) = 0;
+  virtual ~Exporter() {}
 };
 
 } // namespace tabulate

--- a/include/tabulate/latex_exporter.hpp
+++ b/include/tabulate/latex_exporter.hpp
@@ -96,6 +96,8 @@ public:
     return result;
   }
 
+  virtual ~LatexExporter() {}
+
 private:
   std::string add_alignment_header(Table &table) {
     std::string result{"{"};

--- a/include/tabulate/markdown_exporter.hpp
+++ b/include/tabulate/markdown_exporter.hpp
@@ -46,6 +46,8 @@ public:
     return result;
   }
 
+  virtual ~MarkdownExporter() {}
+
 private:
   void add_alignment_header_row(Table &table) {
     auto &rows = table.table_->rows_;

--- a/single_include/tabulate/tabulate.hpp
+++ b/single_include/tabulate/tabulate.hpp
@@ -7117,6 +7117,7 @@ namespace tabulate {
 class Exporter {
 public:
   virtual std::string dump(Table &table) = 0;
+  virtual ~Exporter() {}
 };
 
 } // namespace tabulate
@@ -7167,6 +7168,8 @@ public:
     restore_table_format(table);
     return result;
   }
+
+  virtual ~MarkdownExporter() {}
 
 private:
   void add_alignment_header_row(Table &table) {
@@ -7354,6 +7357,8 @@ public:
     return result;
   }
 
+  virtual ~LatexExporter() {}
+
 private:
   std::string add_alignment_header(Table &table) {
     std::string result{"{"};
@@ -7446,6 +7451,8 @@ public:
     ss << "|===";
     return ss.str();
   }
+
+  virtual ~AsciiDocExporter() {}
 
 private:
   std::string add_formatted_cell(Cell &cell) const {


### PR DESCRIPTION
 _'class tabulate::Exporter' has virtual functions and accessible non-virtual destructor
 'class tabulate::MarkdownExporter' has virtual functions and accessible non-virtual destructor
 'class tabulate::LatexExporter' has virtual functions and accessible non-virtual destructor
 'class tabulate::AsciiDocExporter' has virtual functions and accessible non-virtual destructor_