### PR TITLE
Fix restoring original locales

### DIFF
--- a/include/tabulate/table_internal.hpp
+++ b/include/tabulate/table_internal.hpp
@@ -258,7 +258,7 @@ inline void Printer::print_row_in_cell(std::ostream &stream, TableInternal &tabl
   auto cell = table[index.first][index.second];
   auto locale = cell.locale();
   auto is_multi_byte_character_support_enabled = cell.is_multi_byte_character_support_enabled();
-  std::locale::global(std::locale(locale));
+  auto old_locale = std::locale::global(std::locale(locale));
   auto format = cell.format();
   auto text = cell.get_text();
   auto word_wrapped_text =
@@ -359,6 +359,7 @@ inline void Printer::print_row_in_cell(std::ostream &stream, TableInternal &tabl
       reset_element_style(stream);
     }
   }
+  std::locale::global(old_locale);
 }
 
 inline bool Printer::print_cell_border_top(std::ostream &stream, TableInternal &table,
@@ -367,7 +368,7 @@ inline bool Printer::print_cell_border_top(std::ostream &stream, TableInternal &
                                            size_t num_columns) {
   auto cell = table[index.first][index.second];
   auto locale = cell.locale();
-  std::locale::global(std::locale(locale));
+  auto old_locale = std::locale::global(std::locale(locale));
   auto format = cell.format();
   auto column_width = dimension.second;
 
@@ -400,6 +401,7 @@ inline bool Printer::print_cell_border_top(std::ostream &stream, TableInternal &
     stream << corner;
     reset_element_style(stream);
   }
+  std::locale::global(old_locale);
   return true;
 }
 
@@ -409,7 +411,7 @@ inline bool Printer::print_cell_border_bottom(std::ostream &stream, TableInterna
                                               size_t num_columns) {
   auto cell = table[index.first][index.second];
   auto locale = cell.locale();
-  std::locale::global(std::locale(locale));
+  auto old_locale = std::locale::global(std::locale(locale));
   auto format = cell.format();
   auto column_width = dimension.second;
 
@@ -442,6 +444,7 @@ inline bool Printer::print_cell_border_bottom(std::ostream &stream, TableInterna
     stream << corner;
     reset_element_style(stream);
   }
+  std::locale::global(old_locale);
   return true;
 }
 

--- a/single_include/tabulate/tabulate.hpp
+++ b/single_include/tabulate/tabulate.hpp
@@ -8378,7 +8378,7 @@ inline void Printer::print_row_in_cell(std::ostream &stream, TableInternal &tabl
   auto cell = table[index.first][index.second];
   auto locale = cell.locale();
   auto is_multi_byte_character_support_enabled = cell.is_multi_byte_character_support_enabled();
-  std::locale::global(std::locale(locale));
+  auto old_locale = std::locale::global(std::locale(locale));
   auto format = cell.format();
   auto text = cell.get_text();
   auto word_wrapped_text =
@@ -8479,6 +8479,7 @@ inline void Printer::print_row_in_cell(std::ostream &stream, TableInternal &tabl
       reset_element_style(stream);
     }
   }
+  std::locale::global(old_locale);
 }
 
 inline bool Printer::print_cell_border_top(std::ostream &stream, TableInternal &table,
@@ -8487,7 +8488,7 @@ inline bool Printer::print_cell_border_top(std::ostream &stream, TableInternal &
                                            size_t num_columns) {
   auto cell = table[index.first][index.second];
   auto locale = cell.locale();
-  std::locale::global(std::locale(locale));
+  auto old_locale = std::locale::global(std::locale(locale));
   auto format = cell.format();
   auto column_width = dimension.second;
 
@@ -8520,6 +8521,7 @@ inline bool Printer::print_cell_border_top(std::ostream &stream, TableInternal &
     stream << corner;
     reset_element_style(stream);
   }
+  std::locale::global(old_locale);
   return true;
 }
 
@@ -8529,7 +8531,7 @@ inline bool Printer::print_cell_border_bottom(std::ostream &stream, TableInterna
                                               size_t num_columns) {
   auto cell = table[index.first][index.second];
   auto locale = cell.locale();
-  std::locale::global(std::locale(locale));
+  auto old_locale = std::locale::global(std::locale(locale));
   auto format = cell.format();
   auto column_width = dimension.second;
 
@@ -8562,6 +8564,7 @@ inline bool Printer::print_cell_border_bottom(std::ostream &stream, TableInterna
     stream << corner;
     reset_element_style(stream);
   }
+  std::locale::global(old_locale);
   return true;
 }
 


### PR DESCRIPTION
The locales after printing the table were not restoring thus leaking to the rest of the program. This commit fixes this.