### PR TITLE
Table: Provide size() function returning row counts

### DIFF
--- a/include/tabulate/table.hpp
+++ b/include/tabulate/table.hpp
@@ -39,17 +39,17 @@ SOFTWARE.
 #include <variant>
 using std::get_if;
 using std::holds_alternative;
+using std::string_view;
 using std::variant;
 using std::visit;
-using std::string_view;
 #else
 #include <tabulate/string_view_lite.hpp>
 #include <tabulate/variant_lite.hpp>
 using nonstd::get_if;
 using nonstd::holds_alternative;
+using nonstd::string_view;
 using nonstd::variant;
 using nonstd::visit;
-using nonstd::string_view;
 #endif
 
 #include <utility>
@@ -60,7 +60,8 @@ class Table {
 public:
   Table() : table_(TableInternal::create()) {}
 
-  using Row_t = std::vector<variant<std::string, const char *, string_view, Table>>;
+  using Row_t =
+      std::vector<variant<std::string, const char *, string_view, Table>>;
 
   Table &add_row(const Row_t &cells) {
 
@@ -85,7 +86,7 @@ public:
         cell_strings[i] = *get_if<std::string>(&cell);
       } else if (holds_alternative<const char *>(cell)) {
         cell_strings[i] = *get_if<const char *>(&cell);
-      }  else if (holds_alternative<string_view>(cell)) {
+      } else if (holds_alternative<string_view>(cell)) {
         cell_strings[i] = std::string{*get_if<string_view>(&cell)};
       } else {
         auto table = *get_if<Table>(&cell);
@@ -116,11 +117,14 @@ public:
     return stream.str();
   }
 
+  size_t size() const { return table_->size(); }
+
   std::pair<size_t, size_t> shape() { return table_->shape(); }
 
   class RowIterator {
   public:
-    explicit RowIterator(std::vector<std::shared_ptr<Row>>::iterator ptr) : ptr(ptr) {}
+    explicit RowIterator(std::vector<std::shared_ptr<Row>>::iterator ptr)
+        : ptr(ptr) {}
 
     RowIterator operator++() {
       ++ptr;


### PR DESCRIPTION
Providing a function returning the number of rows is useful for me - I can format the table's rows at once after the table is built according to the number of rows, instead of setting a counter aside. I also saw that the `size()` function is already provided in `TableInternal`, so I think just returning the return value of `table_->size()` is fine.

Since there is no test, here's the testing code that I used to test the feature after I implemented it:

```
#include <cassert>
#include <iostream>
#include <tabulate/table.hpp>

int main() {
  tabulate::Table table;
  assert(table.size() == 0);
  table.add_row({"a", "b"});
  assert(table.size() == 1);
}
```

Also runs `clang-format` script in `table.hpp` file.