### PR TITLE
Improvement: Precalculate the cell content

### DIFF
--- a/include/tabulate/printer.hpp
+++ b/include/tabulate/printer.hpp
@@ -46,18 +46,22 @@ public:
 
   static void print_table(std::ostream &stream, TableInternal &table);
 
-  static void print_row_in_cell(std::ostream &stream, TableInternal &table,
-                                const std::pair<size_t, size_t> &index,
-                                const std::pair<size_t, size_t> &dimension, size_t num_columns,
-                                size_t row_index);
+  static void
+  print_row_in_cell(std::ostream &stream, TableInternal &table,
+                    const std::pair<size_t, size_t> &index,
+                    const std::pair<size_t, size_t> &dimension,
+                    size_t num_columns, size_t row_index,
+                    const std::vector<std::string> &splitted_cell_text);
 
   static bool print_cell_border_top(std::ostream &stream, TableInternal &table,
                                     const std::pair<size_t, size_t> &index,
-                                    const std::pair<size_t, size_t> &dimension, size_t num_columns);
-  static bool print_cell_border_bottom(std::ostream &stream, TableInternal &table,
-                                       const std::pair<size_t, size_t> &index,
-                                       const std::pair<size_t, size_t> &dimension,
-                                       size_t num_columns);
+                                    const std::pair<size_t, size_t> &dimension,
+                                    size_t num_columns);
+  static bool
+  print_cell_border_bottom(std::ostream &stream, TableInternal &table,
+                           const std::pair<size_t, size_t> &index,
+                           const std::pair<size_t, size_t> &dimension,
+                           size_t num_columns);
 
   static void apply_element_style(std::ostream &stream, Color foreground_color,
                                   Color background_color,
@@ -68,21 +72,26 @@ public:
       apply_font_style(stream, style);
   }
 
-  static void reset_element_style(std::ostream &stream) { stream << termcolor::reset; }
+  static void reset_element_style(std::ostream &stream) {
+    stream << termcolor::reset;
+  }
 
 private:
-  static void print_content_left_aligned(std::ostream &stream, const std::string &cell_content,
-                                         const Format &format, size_t text_with_padding_size,
+  static void print_content_left_aligned(std::ostream &stream,
+                                         const std::string &cell_content,
+                                         const Format &format,
+                                         size_t text_with_padding_size,
                                          size_t column_width) {
 
     // Apply font style
-    apply_element_style(stream, *format.font_color_, *format.font_background_color_,
-                        *format.font_style_);
+    apply_element_style(stream, *format.font_color_,
+                        *format.font_background_color_, *format.font_style_);
     stream << cell_content;
     // Only apply font_style to the font
     // Not the padding. So calling apply_element_style with font_style = {}
     reset_element_style(stream);
-    apply_element_style(stream, *format.font_color_, *format.font_background_color_, {});
+    apply_element_style(stream, *format.font_color_,
+                        *format.font_background_color_, {});
 
     if (text_with_padding_size < column_width) {
       for (size_t j = 0; j < (column_width - text_with_padding_size); ++j) {
@@ -91,8 +100,10 @@ private:
     }
   }
 
-  static void print_content_center_aligned(std::ostream &stream, const std::string &cell_content,
-                                           const Format &format, size_t text_with_padding_size,
+  static void print_content_center_aligned(std::ostream &stream,
+                                           const std::string &cell_content,
+                                           const Format &format,
+                                           size_t text_with_padding_size,
                                            size_t column_width) {
     auto num_spaces = column_width - text_with_padding_size;
     if (num_spaces % 2 == 0) {
@@ -101,13 +112,14 @@ private:
         stream << " ";
 
       // Apply font style
-      apply_element_style(stream, *format.font_color_, *format.font_background_color_,
-                          *format.font_style_);
+      apply_element_style(stream, *format.font_color_,
+                          *format.font_background_color_, *format.font_style_);
       stream << cell_content;
       // Only apply font_style to the font
       // Not the padding. So calling apply_element_style with font_style = {}
       reset_element_style(stream);
-      apply_element_style(stream, *format.font_color_, *format.font_background_color_, {});
+      apply_element_style(stream, *format.font_color_,
+                          *format.font_background_color_, {});
 
       for (size_t j = 0; j < num_spaces / 2; ++j)
         stream << " ";
@@ -117,21 +129,24 @@ private:
         stream << " ";
 
       // Apply font style
-      apply_element_style(stream, *format.font_color_, *format.font_background_color_,
-                          *format.font_style_);
+      apply_element_style(stream, *format.font_color_,
+                          *format.font_background_color_, *format.font_style_);
       stream << cell_content;
       // Only apply font_style to the font
       // Not the padding. So calling apply_element_style with font_style = {}
       reset_element_style(stream);
-      apply_element_style(stream, *format.font_color_, *format.font_background_color_, {});
+      apply_element_style(stream, *format.font_color_,
+                          *format.font_background_color_, {});
 
       for (size_t j = 0; j < num_spaces - num_spaces_before; ++j)
         stream << " ";
     }
   }
 
-  static void print_content_right_aligned(std::ostream &stream, const std::string &cell_content,
-                                          const Format &format, size_t text_with_padding_size,
+  static void print_content_right_aligned(std::ostream &stream,
+                                          const std::string &cell_content,
+                                          const Format &format,
+                                          size_t text_with_padding_size,
                                           size_t column_width) {
     if (text_with_padding_size < column_width) {
       for (size_t j = 0; j < (column_width - text_with_padding_size); ++j) {
@@ -140,13 +155,14 @@ private:
     }
 
     // Apply font style
-    apply_element_style(stream, *format.font_color_, *format.font_background_color_,
-                        *format.font_style_);
+    apply_element_style(stream, *format.font_color_,
+                        *format.font_background_color_, *format.font_style_);
     stream << cell_content;
     // Only apply font_style to the font
     // Not the padding. So calling apply_element_style with font_style = {}
     reset_element_style(stream);
-    apply_element_style(stream, *format.font_color_, *format.font_background_color_, {});
+    apply_element_style(stream, *format.font_color_,
+                        *format.font_background_color_, {});
   }
 
   static void apply_font_style(std::ostream &stream, FontStyle style) {
@@ -180,7 +196,8 @@ private:
     }
   }
 
-  static void apply_foreground_color(std::ostream &stream, Color foreground_color) {
+  static void apply_foreground_color(std::ostream &stream,
+                                     Color foreground_color) {
     switch (foreground_color) {
     case Color::grey:
       stream << termcolor::grey;
@@ -212,7 +229,8 @@ private:
     }
   }
 
-  static void apply_background_color(std::ostream &stream, Color background_color) {
+  static void apply_background_color(std::ostream &stream,
+                                     Color background_color) {
     switch (background_color) {
     case Color::grey:
       stream << termcolor::on_grey;


### PR DESCRIPTION
* Fix a bug that the cell's height is miscalculated when there's a left-right-padding setting and the word is getting separated.

Cause: In `print_row_in_cell`, the text is wrapped (by `word_wrap`) and split (by `split_lines`) too early before checking the padding settings. 

* Precalculate and cache the result of `word_wrap` and `split_lines` before calling `print_row_in_cell` to improve the printing complixity

Detail: In `print_row_in_cell`, `word_wrap` and `split_lines` will be called once for each cell each line they have. When the content of the cell and the number of lines are both large, the computation time will grow massively.

In this PR, the computation is moved before the actual printing procedure, so those functions won't get called multiple times for each cell, and also avoid the bug mentioned by using the correct line height in `print_row_in_cell`.

Further todo: the code in `Row::get_cell_height` is also similar to these, maybe we should reuse the code.

The example of the bug (the upper one is before, and the lower one is after):
![image](https://user-images.githubusercontent.com/15229692/217427133-1ef45f8e-6ca0-4c24-b4ff-4f615507309e.png)

Reproduce code: 
```=c
Table table;

table.add_row({"abcde"});

table.format().width(10);
table.format().padding_left(4);
table.format().padding_right(4);

cout << table << endl;
```

Additional check for not breaking another sample:
![image](https://user-images.githubusercontent.com/15229692/217427221-9c85a93c-93bf-4430-8984-1bb0ebe0e9ab.png)

I did a manual check for all the samples and hope there's no accident.

* Apply clang-format for all the files changed in this PR.