### PR TITLE
Fixed handling system-provided thread libraries when building samples

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Threads REQUIRED)
+
 add_executable(class_diagram class_diagram.cpp)
 target_link_libraries(class_diagram PRIVATE tabulate::tabulate)
 
@@ -50,7 +52,7 @@ add_executable(asciidoc_export asciidoc_export.cpp)
 target_link_libraries(asciidoc_export PRIVATE tabulate::tabulate)
 
 add_executable(refresh_table refresh_table.cpp) 
-target_link_libraries(refresh_table PRIVATE tabulate::tabulate pthread)
+target_link_libraries(refresh_table PRIVATE tabulate::tabulate ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable(string_view_in_row string_view_in_row.cpp) 
-target_link_libraries(string_view_in_row PRIVATE tabulate::tabulate pthread)
+target_link_libraries(string_view_in_row PRIVATE tabulate::tabulate ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
Went to check out the samples on `MSVC 19.33.31630.0` and got hit with:
```
LINK : fatal error LNK1104: cannot open file 'pthread.lib' [C:\dev\tabulate\build\samples\refresh_table.vcxproj]
LINK : fatal error LNK1104: cannot open file 'pthread.lib' [C:\dev\tabulate\build\samples\string_view_in_row.vcxproj]
```
<details><summary>repro</summary>
<pre><code>C:\dev>git clone https://github.com/p-ranav/tabulate
Cloning into 'tabulate'...
remote: Enumerating objects: 2141, done.
remote: Counting objects: 100% (181/181), done.
remote: Compressing objects: 100% (85/85), done.
remote: Total 2141 (delta 87), reused 147 (delta 70), pack-reused 1960
Receiving objects: 100% (2141/2141), 9.53 MiB | 22.68 MiB/s, done.
Resolving deltas: 100% (1311/1311), done.

C:\dev>cd tabulate && mkdir build && cd build

C:\dev\tabulate\build>cmake .. -DSAMPLES=ON && cmake --build .
-- Building for: Visual Studio 17 2022
-- Selecting Windows SDK version 10.0.19041.0 to target Windows 10.0.22621.
-- The CXX compiler identification is MSVC 19.33.31630.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.33.31629/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- tabulate version: v1.5.0
-- Using C++11
-- Configuring done
-- Generating done
-- Build files have been written to: C:/dev/tabulate/build
MSBuild version 17.3.1+2badb37d1 for .NET Framework
  Checking Build System
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  asciidoc_export.cpp
  The contents of <optional> are available only with C++17 or later.
  asciidoc_export.vcxproj -> C:\dev\tabulate\build\samples\Debug\asciidoc_export.exe
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  class_diagram.cpp
  class_diagram.vcxproj -> C:\dev\tabulate\build\samples\Debug\class_diagram.exe
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  colors.cpp
  colors.vcxproj -> C:\dev\tabulate\build\samples\Debug\colors.exe
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  employees.cpp
  employees.vcxproj -> C:\dev\tabulate\build\samples\Debug\employees.exe
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  font_styles.cpp
  font_styles.vcxproj -> C:\dev\tabulate\build\samples\Debug\font_styles.exe
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  iterators.cpp
  iterators.vcxproj -> C:\dev\tabulate\build\samples\Debug\iterators.exe
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  latex_export.cpp
  latex_export.vcxproj -> C:\dev\tabulate\build\samples\Debug\latex_export.exe
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  mario.cpp
  mario.vcxproj -> C:\dev\tabulate\build\samples\Debug\mario.exe
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  markdown_export.cpp
  markdown_export.vcxproj -> C:\dev\tabulate\build\samples\Debug\markdown_export.exe
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  movies.cpp
  movies.vcxproj -> C:\dev\tabulate\build\samples\Debug\movies.exe
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  padding.cpp
  padding.vcxproj -> C:\dev\tabulate\build\samples\Debug\padding.exe
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  refresh_table.cpp
LINK : fatal error LNK1104: cannot open file 'pthread.lib' [C:\dev\tabulate\build\samples\refresh_table.vcxproj]
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  runic.cpp
  runic.vcxproj -> C:\dev\tabulate\build\samples\Debug\runic.exe
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  shape.cpp
  shape.vcxproj -> C:\dev\tabulate\build\samples\Debug\shape.exe
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  string_view_in_row.cpp
LINK : fatal error LNK1104: cannot open file 'pthread.lib' [C:\dev\tabulate\build\samples\string_view_in_row.vcxproj]
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  summary.cpp
  summary.vcxproj -> C:\dev\tabulate\build\samples\Debug\summary.exe
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  unicode.cpp
  unicode.vcxproj -> C:\dev\tabulate\build\samples\Debug\unicode.exe
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  universal_constants.cpp
  universal_constants.vcxproj -> C:\dev\tabulate\build\samples\Debug\universal_constants.exe
  Building Custom Rule C:/dev/tabulate/samples/CMakeLists.txt
  word_wrapping.cpp
  word_wrapping.vcxproj -> C:\dev\tabulate\build\samples\Debug\word_wrapping.exe

C:\dev\tabulate\build></code></pre></details>

Swapped the `pthread`'s with [`${CMAKE_THREAD_LIBS_INIT}`](https://cmake.org/cmake/help/latest/module/FindThreads.html)'s and presto! 