### PR TITLE
Add an option to control the cell trimming.

### DIFF
--- a/include/tabulate/format.hpp
+++ b/include/tabulate/format.hpp
@@ -381,6 +381,18 @@ public:
     locale_ = value;
     return *this;
   }
+  
+  enum class TrimMode {
+    kNone = 0,
+    kLeft = 1 << 0,
+    kRight = 1 << 1,
+    kBoth = kLeft | kRight,
+  };
+  
+  Format &trim_mode(TrimMode trim_mode) {
+    trim_mode_ = trim_mode;
+    return *this;
+  }
 
   // Apply word wrap
   // Given an input string and a line length, this will insert \n
@@ -683,6 +695,11 @@ public:
     else
       result.locale_ = second.locale_;
 
+    if (first.trim_mode_.has_value())
+      result.trim_mode_ = first.trim_mode_;
+    else
+      result.trim_mode_ = second.trim_mode_;
+
     return result;
   }
 
@@ -718,6 +735,7 @@ private:
     column_separator_color_ = column_separator_background_color_ = Color::none;
     multi_byte_characters_ = false;
     locale_ = "";
+    trim_mode_ = TrimMode::kBoth;
   }
 
   // Helper methods for word wrapping:
@@ -849,6 +867,8 @@ private:
   // Internationalization
   optional<bool> multi_byte_characters_{};
   optional<std::string> locale_{};
+  
+  optional<TrimMode> trim_mode_{};
 };
 
 } // namespace tabulate

--- a/include/tabulate/table_internal.hpp
+++ b/include/tabulate/table_internal.hpp
@@ -327,7 +327,20 @@ inline void Printer::print_row_in_cell(std::ostream &stream, TableInternal &tabl
       stream << std::string(padding_left, ' ');
 
       // Print word-wrapped line
-      line = Format::trim(line);
+      switch (*format.trim_mode_) {
+        case Format::TrimMode::kBoth:
+          line = Format::trim(line);
+          break;
+        case Format::TrimMode::kLeft:
+          line = Format::trim_left(line);
+          break;
+        case Format::TrimMode::kRight:
+          line = Format::trim_right(line);
+          break;
+        case Format::TrimMode::kNone:
+          break;
+      }
+      
       auto line_with_padding_size =
           get_sequence_length(line, cell.locale(), is_multi_byte_character_support_enabled) +
           padding_left + padding_right;

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -27,6 +27,9 @@ target_link_libraries(mario PRIVATE tabulate::tabulate)
 add_executable(movies movies.cpp)
 target_link_libraries(movies PRIVATE tabulate::tabulate)
 
+add_executable(no_trim no_trim.cpp)
+target_link_libraries(no_trim PRIVATE tabulate::tabulate)
+
 add_executable(padding padding.cpp)
 target_link_libraries(padding PRIVATE tabulate::tabulate)
 

--- a/samples/no_trim.cpp
+++ b/samples/no_trim.cpp
@@ -1,0 +1,11 @@
+#include <tabulate/table.hpp>
+using namespace tabulate;
+using Row_t = Table::Row_t;
+
+int main() {
+  Table table;
+  table.format().trim_mode(Format::TrimMode::kNone);
+  table.add_row(Row_t{"This is\na cell that\nspans\nmultiple lines"});
+  table.add_row(Row_t{"{\n  foo\n  bar\n}"});
+  std::cout << table << std::endl;
+}


### PR DESCRIPTION
This is useful when cells contain text where indentation is important (like JSON or XML).

This change preserves the existing behaviour (both left and right trimming is done by default).

Example output from `no_trim` sample:

```
+----------------+
| This is        |
| a cell that    |
| spans          |
| multiple lines |
+----------------+
| {              |
|   foo          |
|   bar          |
| }              |
+----------------+
```