### PR TITLE
add stream insertion for rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ int main() {
   universal_constants.add_row({"Speed of light in vacuum", "299 792 458 m·s⁻¹"});
 ```
 
+Use `RowStream` to format table data with stream insertion.
+
+```cpp
+  employees.add_row({"Emp. ID", "First Name", "Last Name", "Department / Business Unit", "Pay Rate"});
+  employees.add_row(RowStream{} << 101 << "Donald" << "Patrick" << "Finance" << 59.6154);
+  employees.add_row(RowStream{} << 102 << "Rachel" << "Williams" << "Marketing and Operational\nLogistics Planning" << 34.9707);
+  employees.add_row(RowStream{} << 103 << "Ian" << "Jacob" << department << 57.0048);
+```
+
 You can format this table using `Table.format()` which returns a `Format` object. Using a fluent interface, format properties of the table, e.g., borders, font styles, colors etc.
 
 ```cpp

--- a/include/tabulate/format.hpp
+++ b/include/tabulate/format.hpp
@@ -381,14 +381,14 @@ public:
     locale_ = value;
     return *this;
   }
-  
+
   enum class TrimMode {
     kNone = 0,
     kLeft = 1 << 0,
     kRight = 1 << 1,
     kBoth = kLeft | kRight,
   };
-  
+
   Format &trim_mode(TrimMode trim_mode) {
     trim_mode_ = trim_mode;
     return *this;
@@ -867,7 +867,7 @@ private:
   // Internationalization
   optional<bool> multi_byte_characters_{};
   optional<std::string> locale_{};
-  
+
   optional<TrimMode> trim_mode_{};
 };
 

--- a/include/tabulate/table.hpp
+++ b/include/tabulate/table.hpp
@@ -154,4 +154,68 @@ inline std::ostream &operator<<(std::ostream &stream, const Table &table) {
   return stream;
 }
 
+class RowStream {
+public:
+  operator const Table::Row_t &() const { return row_; }
+
+  template <typename T, typename = typename std::enable_if<
+                            !std::is_convertible<T, Table::Row_t::value_type>::value>::type>
+  RowStream &operator<<(const T &obj) {
+    oss_ << obj;
+    std::string cell{oss_.str()};
+    oss_.str("");
+    if (!cell.empty()) {
+      row_.push_back(cell);
+    }
+    return *this;
+  }
+
+  RowStream &operator<<(const Table::Row_t::value_type &cell) {
+    row_.push_back(cell);
+    return *this;
+  }
+
+  RowStream &copyfmt(const RowStream &other) {
+    oss_.copyfmt(other.oss_);
+    return *this;
+  }
+
+  RowStream &copyfmt(const std::ios &other) {
+    oss_.copyfmt(other);
+    return *this;
+  }
+
+  std::ostringstream::char_type fill() const { return oss_.fill(); }
+  std::ostringstream::char_type fill(std::ostringstream::char_type ch) { return oss_.fill(ch); }
+
+  std::ios_base::iostate exceptions() const { return oss_.exceptions(); }
+  void exceptions(std::ios_base::iostate except) { oss_.exceptions(except); }
+
+  std::locale imbue(const std::locale &loc) { return oss_.imbue(loc); }
+  std::locale getloc() const { return oss_.getloc(); }
+
+  char narrow(std::ostringstream::char_type c, char dfault) const { return oss_.narrow(c, dfault); }
+  std::ostringstream::char_type widen(char c) const { return oss_.widen(c); }
+
+  std::ios::fmtflags flags() const { return oss_.flags(); }
+  std::ios::fmtflags flags(std::ios::fmtflags flags) { return oss_.flags(flags); }
+
+  std::ios::fmtflags setf(std::ios::fmtflags flags) { return oss_.setf(flags); }
+  std::ios::fmtflags setf(std::ios::fmtflags flags, std::ios::fmtflags mask) {
+    return oss_.setf(flags, mask);
+  }
+
+  void unsetf(std::ios::fmtflags flags) { oss_.unsetf(flags); }
+
+  std::streamsize precision() const { return oss_.precision(); }
+  std::streamsize precision(std::streamsize new_precision) { return oss_.precision(new_precision); }
+
+  std::streamsize width() const { return oss_.width(); }
+  std::streamsize width(std::streamsize new_width) { return oss_.width(new_width); }
+
+private:
+  Table::Row_t row_;
+  std::ostringstream oss_;
+};
+
 } // namespace tabulate

--- a/include/tabulate/table_internal.hpp
+++ b/include/tabulate/table_internal.hpp
@@ -328,19 +328,19 @@ inline void Printer::print_row_in_cell(std::ostream &stream, TableInternal &tabl
 
       // Print word-wrapped line
       switch (*format.trim_mode_) {
-        case Format::TrimMode::kBoth:
-          line = Format::trim(line);
-          break;
-        case Format::TrimMode::kLeft:
-          line = Format::trim_left(line);
-          break;
-        case Format::TrimMode::kRight:
-          line = Format::trim_right(line);
-          break;
-        case Format::TrimMode::kNone:
-          break;
+      case Format::TrimMode::kBoth:
+        line = Format::trim(line);
+        break;
+      case Format::TrimMode::kLeft:
+        line = Format::trim_left(line);
+        break;
+      case Format::TrimMode::kRight:
+        line = Format::trim_right(line);
+        break;
+      case Format::TrimMode::kNone:
+        break;
       }
-      
+
       auto line_with_padding_size =
           get_sequence_length(line, cell.locale(), is_multi_byte_character_support_enabled) +
           padding_left + padding_right;

--- a/samples/employees.cpp
+++ b/samples/employees.cpp
@@ -1,3 +1,4 @@
+#include <iomanip>
 #include <tabulate/table.hpp>
 using namespace tabulate;
 using Row_t = Table::Row_t;
@@ -8,12 +9,16 @@ int main() {
   Table department;
   department.add_row(Row_t{"Research", "Engineering"});
 
+  RowStream rs;
+  rs << std::setprecision(10);
+
   // Add rows
-  employees.add_row(Row_t{"Emp. ID", "First Name", "Last Name", "Department / Business Unit"});
-  employees.add_row(Row_t{"101", "Donald", "Patrick", "Finance"});
-  employees.add_row(
-      Row_t{"102", "Rachel", "Williams", "Marketing and Operational\nLogistics Planning"});
-  employees.add_row(Row_t{"103", "Ian", "Jacob", department});
+  // clang-format off
+  employees.add_row(Row_t{"Emp. ID", "First Name", "Last Name", "Department / Business Unit", "Pay Rate"});
+  employees.add_row(RowStream{}.copyfmt(rs) << 101 << "Donald" << "Patrick" << "Finance" << 59.61538461);
+  employees.add_row(RowStream{}.copyfmt(rs) << 102 << "Rachel" << "Williams" << "Marketing and Operational\nLogistics Planning" << 34.97067307);
+  employees.add_row(RowStream{}.copyfmt(rs) << 103 << "Ian" << "Jacob" << department << 57.00480769);
+  // clang-format on
 
   employees.column(0)
       .format()


### PR DESCRIPTION
The existing `Table::add_row` member function is limited to accepting only strings and inner tables. In many cases, the data being added to a table is not string data, and forcing applications to always serialize that data before calling `add_row` may be needlessly cumbersome (at least it often feels that way when I am using the library).

This PR adds a `RowStream` class that takes advantage of `std::ostringstream` formatting to streamline application code.

`RowStream` is implicitly convertible to a `Table::Row_t` to minimize disruption to the existing API.
```cpp
table.add_row(RowStream{} << 101 << "Donald" << "Patrick" << "Finance" << 59.6154);
```

`RowStream` is expected to provide all the standard formatting behavior of `std::ostringstream` (e.g. `.imbue(...)`, `.precision(...)`, `<< std::setprecision(...)`, etc.). Thus more complex formatting is supported.

---

Another possible option that I considered would be to add another `add_row` overload (or perhaps a differently named member function) that returns a similar `RowStream` object that adds the row data when it goes out of scope. This option would allow for the following application code:
```cpp
table.add_row() << 101 << "Donald" << "Patrick" << "Finance" << 59.6154;
```
While it is more concise, I ruled against this option because I think it is more foreign to the existing API. However, if there is interest I would be willing to change the implementation accordingly.

---

I also considered a variadic template solution, but then formatting options would be significantly limited.

---

Thank you for your consideration.