### PR TITLE
Allow printing only the inside separators

### DIFF
--- a/include/tabulate/format.hpp
+++ b/include/tabulate/format.hpp
@@ -234,14 +234,12 @@ public:
     return *this;
   }
 
-  Format& show_column_separator()
-  {
+  Format& show_column_separator() {
     show_column_separator_ = true;
 	  return *this;
   }
 
-  Format& show_row_separator()
-  {
+  Format& show_row_separator() {
     show_border_top_ = true;
     show_row_separator_ = true;
     return *this;

--- a/include/tabulate/format.hpp
+++ b/include/tabulate/format.hpp
@@ -240,6 +240,13 @@ public:
 	  return *this;
   }
 
+  Format& show_row_separator()
+  {
+    show_border_top_ = true;
+    show_row_separator_ = true;
+    return *this;
+  }
+
   Format &corner(const std::string &value) {
     corner_top_left_ = value;
     corner_top_right_ = value;
@@ -711,6 +718,11 @@ public:
     else
       result.trim_mode_ = second.trim_mode_;
 
+    if (first.show_row_separator_.has_value())
+		  result.show_row_separator_ = first.show_row_separator_;
+	  else
+		  result.show_row_separator_ = second.show_row_separator_;
+
     return result;
   }
 
@@ -748,6 +760,7 @@ private:
     multi_byte_characters_ = false;
     locale_ = "";
     trim_mode_ = TrimMode::kBoth;
+    show_row_separator_ = false;
   }
 
   // Helper methods for word wrapping:
@@ -882,6 +895,8 @@ private:
   optional<std::string> locale_{};
 
   optional<TrimMode> trim_mode_{};
+
+  optional<bool> show_row_separator_{};
 };
 
 } // namespace tabulate

--- a/include/tabulate/format.hpp
+++ b/include/tabulate/format.hpp
@@ -234,6 +234,12 @@ public:
     return *this;
   }
 
+  Format& show_column_separator()
+  {
+    show_column_separator_ = true;
+	  return *this;
+  }
+
   Format &corner(const std::string &value) {
     corner_top_left_ = value;
     corner_top_right_ = value;
@@ -669,6 +675,11 @@ public:
       result.corner_bottom_right_background_color_ = second.corner_bottom_right_background_color_;
 
     // Column separator
+    if (first.show_column_separator_.has_value())
+   	  result.show_column_separator_ = first.show_column_separator_;
+    else
+	    result.show_column_separator_ = second.show_column_separator_;
+
     if (first.column_separator_.has_value())
       result.column_separator_ = first.column_separator_;
     else
@@ -731,6 +742,7 @@ private:
         corner_top_right_background_color_ = corner_bottom_left_color_ =
             corner_bottom_left_background_color_ = corner_bottom_right_color_ =
                 corner_bottom_right_background_color_ = Color::none;
+    show_column_separator_ = true;
     column_separator_ = "|";
     column_separator_color_ = column_separator_background_color_ = Color::none;
     multi_byte_characters_ = false;
@@ -860,6 +872,7 @@ private:
   optional<Color> corner_bottom_right_background_color_{};
 
   // Element column separator
+  optional<bool> show_column_separator_{};
   optional<std::string> column_separator_{};
   optional<Color> column_separator_color_{};
   optional<Color> column_separator_background_color_{};

--- a/include/tabulate/table_internal.hpp
+++ b/include/tabulate/table_internal.hpp
@@ -309,6 +309,14 @@ inline void Printer::print_row_in_cell(std::ostream &stream, TableInternal &tabl
     reset_element_style(stream);
   }
 
+  if (*format.show_column_separator_) {
+    apply_element_style(stream, *format.column_separator_color_, *format.column_separator_background_color_,
+                        {});
+   	if (index.second != 0)
+		  stream << *format.column_separator_;
+    reset_element_style(stream);
+  }
+
   apply_element_style(stream, *format.font_color_, *format.font_background_color_, {});
   if (row_index < padding_top) {
     // Padding top

--- a/include/tabulate/table_internal.hpp
+++ b/include/tabulate/table_internal.hpp
@@ -407,13 +407,26 @@ inline bool Printer::print_cell_border_top(std::ostream &stream, TableInternal &
     return false;
 
   apply_element_style(stream, corner_color, corner_background_color, {});
-  stream << corner;
+  if (*format.show_row_separator_) {
+    if (index.first != 0)
+      stream << corner;
+    else
+      stream << " ";
+  }
+  else
+    stream << corner;
   reset_element_style(stream);
 
   for (size_t i = 0; i < column_width; ++i) {
     apply_element_style(stream, *format.border_top_color_, *format.border_top_background_color_,
                         {});
-    stream << border_top;
+    if (*format.show_row_separator_) {
+      if (index.first != 0)
+        stream << border_top;
+      else
+        stream << " ";
+    } else
+      stream << border_top;
     reset_element_style(stream);
   }
 
@@ -424,7 +437,14 @@ inline bool Printer::print_cell_border_top(std::ostream &stream, TableInternal &
     corner_background_color = *format.corner_top_right_background_color_;
 
     apply_element_style(stream, corner_color, corner_background_color, {});
-    stream << corner;
+    if (*format.show_row_separator_) {
+      if (index.first != 0)
+        stream << corner;
+      else
+        stream << " ";
+    }
+    else
+      stream << corner;
     reset_element_style(stream);
   }
   std::locale::global(old_locale);

--- a/single_include/tabulate/tabulate.hpp
+++ b/single_include/tabulate/tabulate.hpp
@@ -6559,6 +6559,13 @@ public:
 	  return *this;
   }
 
+  Format& show_row_separator()
+  {
+    show_border_top_ = true;
+    show_row_separator_ = true;
+    return *this;
+  }
+
   Format &corner(const std::string &value) {
     corner_top_left_ = value;
     corner_top_right_ = value;
@@ -7030,6 +7037,11 @@ public:
     else
       result.trim_mode_ = second.trim_mode_;
 
+    if (first.show_row_separator_.has_value())
+		  result.show_row_separator_ = first.show_row_separator_;
+	  else
+		  result.show_row_separator_ = second.show_row_separator_;
+
     return result;
   }
 
@@ -7067,6 +7079,7 @@ private:
     multi_byte_characters_ = false;
     locale_ = "";
     trim_mode_ = TrimMode::kBoth;
+    show_row_separator_ = false;
   }
 
   // Helper methods for word wrapping:
@@ -7201,6 +7214,8 @@ private:
   optional<std::string> locale_{};
 
   optional<TrimMode> trim_mode_{};
+
+  optional<bool> show_row_separator_{};
 };
 
 } // namespace tabulate
@@ -8573,13 +8588,26 @@ inline bool Printer::print_cell_border_top(std::ostream &stream, TableInternal &
     return false;
 
   apply_element_style(stream, corner_color, corner_background_color, {});
-  stream << corner;
+  if (*format.show_row_separator_) {
+    if (index.first != 0)
+      stream << corner;
+    else
+      stream << " ";
+  }
+  else
+    stream << corner;
   reset_element_style(stream);
 
   for (size_t i = 0; i < column_width; ++i) {
     apply_element_style(stream, *format.border_top_color_, *format.border_top_background_color_,
                         {});
-    stream << border_top;
+    if (*format.show_row_separator_) {
+      if (index.first != 0)
+        stream << border_top;
+      else
+        stream << " ";
+    } else
+      stream << border_top;
     reset_element_style(stream);
   }
 
@@ -8590,7 +8618,14 @@ inline bool Printer::print_cell_border_top(std::ostream &stream, TableInternal &
     corner_background_color = *format.corner_top_right_background_color_;
 
     apply_element_style(stream, corner_color, corner_background_color, {});
-    stream << corner;
+    if (*format.show_row_separator_) {
+      if (index.first != 0)
+        stream << corner;
+      else
+        stream << " ";
+    }
+    else
+      stream << corner;
     reset_element_style(stream);
   }
   std::locale::global(old_locale);

--- a/single_include/tabulate/tabulate.hpp
+++ b/single_include/tabulate/tabulate.hpp
@@ -6553,14 +6553,12 @@ public:
     return *this;
   }
 
-  Format& show_column_separator()
-  {
+  Format& show_column_separator() {
     show_column_separator_ = true;
 	  return *this;
   }
 
-  Format& show_row_separator()
-  {
+  Format& show_row_separator() {
     show_border_top_ = true;
     show_row_separator_ = true;
     return *this;

--- a/single_include/tabulate/tabulate.hpp
+++ b/single_include/tabulate/tabulate.hpp
@@ -6553,6 +6553,12 @@ public:
     return *this;
   }
 
+  Format& show_column_separator()
+  {
+    show_column_separator_ = true;
+	  return *this;
+  }
+
   Format &corner(const std::string &value) {
     corner_top_left_ = value;
     corner_top_right_ = value;
@@ -6988,6 +6994,11 @@ public:
       result.corner_bottom_right_background_color_ = second.corner_bottom_right_background_color_;
 
     // Column separator
+    if (first.show_column_separator_.has_value())
+   	  result.show_column_separator_ = first.show_column_separator_;
+    else
+	    result.show_column_separator_ = second.show_column_separator_;
+
     if (first.column_separator_.has_value())
       result.column_separator_ = first.column_separator_;
     else
@@ -7050,6 +7061,7 @@ private:
         corner_top_right_background_color_ = corner_bottom_left_color_ =
             corner_bottom_left_background_color_ = corner_bottom_right_color_ =
                 corner_bottom_right_background_color_ = Color::none;
+    show_column_separator_ = true;
     column_separator_ = "|";
     column_separator_color_ = column_separator_background_color_ = Color::none;
     multi_byte_characters_ = false;
@@ -7179,6 +7191,7 @@ private:
   optional<Color> corner_bottom_right_background_color_{};
 
   // Element column separator
+  optional<bool> show_column_separator_{};
   optional<std::string> column_separator_{};
   optional<Color> column_separator_color_{};
   optional<Color> column_separator_background_color_{};
@@ -8459,6 +8472,14 @@ inline void Printer::print_row_in_cell(std::ostream &stream, TableInternal &tabl
     apply_element_style(stream, *format.border_left_color_, *format.border_left_background_color_,
                         {});
     stream << *format.border_left_;
+    reset_element_style(stream);
+  }
+
+  if (*format.show_column_separator_) {
+    apply_element_style(stream, *format.column_separator_color_, *format.column_separator_background_color_,
+                        {});
+   	if (index.second != 0)
+		  stream << *format.column_separator_;
     reset_element_style(stream);
   }
 


### PR DESCRIPTION
Example code:
```cpp
<table>.format().hide_border().show_column_separator().show_row_separator();
```
Will create a table like this:
![image](https://github.com/p-ranav/tabulate/assets/63854611/ec744768-e419-408f-a266-0869c50e4ca0)
