### PR TITLE
fix reverting locale in single_include

### DIFF
--- a/include/tabulate/table_internal.hpp
+++ b/include/tabulate/table_internal.hpp
@@ -403,8 +403,10 @@ inline bool Printer::print_cell_border_top(std::ostream &stream, TableInternal &
   auto corner_background_color = *format.corner_top_left_background_color_;
   auto border_top = *format.border_top_;
 
-  if ((corner == "" && border_top == "") || !*format.show_border_top_)
+  if ((corner == "" && border_top == "") || !*format.show_border_top_) {
+    std::locale::global(old_locale);
     return false;
+  }
 
   apply_element_style(stream, corner_color, corner_background_color, {});
   if (*format.show_row_separator_) {
@@ -466,8 +468,10 @@ inline bool Printer::print_cell_border_bottom(std::ostream &stream, TableInterna
   auto corner_background_color = *format.corner_bottom_left_background_color_;
   auto border_bottom = *format.border_bottom_;
 
-  if ((corner == "" && border_bottom == "") || !*format.show_border_bottom_)
+  if ((corner == "" && border_bottom == "") || !*format.show_border_bottom_) {
+    std::locale::global(old_locale);
     return false;
+  }
 
   apply_element_style(stream, corner_color, corner_background_color, {});
   stream << corner;

--- a/single_include/tabulate/tabulate.hpp
+++ b/single_include/tabulate/tabulate.hpp
@@ -8582,8 +8582,10 @@ inline bool Printer::print_cell_border_top(std::ostream &stream, TableInternal &
   auto corner_background_color = *format.corner_top_left_background_color_;
   auto border_top = *format.border_top_;
 
-  if ((corner == "" && border_top == "") || !*format.show_border_top_)
+  if ((corner == "" && border_top == "") || !*format.show_border_top_) {
+    std::locale::global(old_locale);
     return false;
+  }
 
   apply_element_style(stream, corner_color, corner_background_color, {});
   if (*format.show_row_separator_) {
@@ -8645,8 +8647,10 @@ inline bool Printer::print_cell_border_bottom(std::ostream &stream, TableInterna
   auto corner_background_color = *format.corner_bottom_left_background_color_;
   auto border_bottom = *format.border_bottom_;
 
-  if ((corner == "" && border_bottom == "") || !*format.show_border_bottom_)
+  if ((corner == "" && border_bottom == "") || !*format.show_border_bottom_) {
+    std::locale::global(old_locale);
     return false;
+  }
 
   apply_element_style(stream, corner_color, corner_background_color, {});
   stream << corner;


### PR DESCRIPTION
Looks like the author of pull-request  #110 didn't change the single include file. This PR complements it. 

I verified that this fixes an issue that I encountered in my tool which uses tabulate. The tool is supposed to use "C" locale, but after printing a 'tabulate' table, it gets changed to the environment locale (because format's default locale is "") and then subsequent writes to new files use the environment locale instead of "C".

@p-ranav - if you want I can include the changes from #110 here as well - let me know.