### PR TITLE
Add C++20 modules support with CMake integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,10 @@ include(GNUInstallDirs)
 add_library(tabulate INTERFACE)
 add_library(tabulate::tabulate ALIAS tabulate)
 
-if (USE_CPP17)
+if (USE_CPP20)
+  target_compile_features(tabulate INTERFACE cxx_std_20)
+  message(STATUS "Using C++20")
+elseif (USE_CPP17)
   target_compile_features(tabulate INTERFACE cxx_std_17)
   message(STATUS "Using C++17")
 else()
@@ -52,6 +55,40 @@ if( SAMPLES )
   add_subdirectory(samples)
 endif()
 
+# C++20 Module Support
+# ====================
+# Enabled when USE_CPP20 is set and CMake >= 3.28
+# Can be disabled by setting TABULATE_BUILD_MODULE=OFF
+# Note: Requires a generator that supports C++20 modules (Ninja or Visual Studio 17.4+)
+
+set(TABULATE_MODULE_TARGET_CREATED FALSE)
+
+# Build module when USE_CPP20 is enabled and CMake version supports it
+if(USE_CPP20 AND NOT CMAKE_VERSION VERSION_LESS "3.28")
+  option(TABULATE_BUILD_MODULE "Build C++20 module" ON)
+
+  if(TABULATE_BUILD_MODULE)
+    message(STATUS "Building C++20 module")
+
+    # Enable module scanning
+    set(CMAKE_CXX_SCAN_FOR_MODULES ON)
+
+    add_library(tabulate_module)
+    target_sources(tabulate_module
+      PUBLIC
+        FILE_SET CXX_MODULES FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/tabulate/tabulate.cppm
+    )
+    target_compile_features(tabulate_module PUBLIC cxx_std_20)
+    target_include_directories(tabulate_module PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+    add_library(tabulate::tabulate_module ALIAS tabulate_module)
+    set(TABULATE_MODULE_TARGET_CREATED TRUE)
+  endif()
+endif()
+
 configure_package_config_file(tabulateConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/tabulateConfig.cmake
   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tabulate)
@@ -61,6 +98,10 @@ write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Conf
                                  COMPATIBILITY AnyNewerVersion)
 
 install(TARGETS tabulate EXPORT tabulateTargets)
+if(TABULATE_MODULE_TARGET_CREATED)
+  install(TARGETS tabulate_module EXPORT tabulateTargets
+          FILE_SET CXX_MODULES DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
 install(EXPORT tabulateTargets
         FILE tabulateTargets.cmake
         NAMESPACE tabulate::
@@ -71,4 +112,5 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tabulateConfig.cmake
 install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/tabulate
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         USE_SOURCE_PERMISSIONS
-        PATTERN "*.hpp")
+        PATTERN "*.hpp"
+        PATTERN "*.cppm")

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 ## Table of Contents
 
 *   [Quick Start](#quick-start)
+*   [Integration Guide](USING.md)
 *   [Formatting Options](#formatting-options)
     *   [Style Inheritance Model](#style-inheritance-model)
     *   [Word Wrapping](#word-wrapping)
@@ -50,7 +51,9 @@
 
 `tabulate` is a header-only library. Just add `include/` to your `include_directories` and you should be good to go. A single header file version is also available in `single_include/`.
 
-**NOTE** Tabulate supports `>=C++11`. The rest of this README, however, assumes `C++17` support. 
+**NOTE** Tabulate supports `>=C++11`. The rest of this README, however, assumes `C++17` support.
+
+For detailed integration instructions including CMake FetchContent, find_package, and C++20 modules support, see [USING.md](USING.md).
 
 Create a `Table` object and call `Table.add_rows` to add rows to your table.
 

--- a/USING.md
+++ b/USING.md
@@ -1,0 +1,165 @@
+# Using tabulate
+
+This guide covers different ways to integrate tabulate into your C++ project.
+
+## Table of Contents
+
+- [Header-Only Usage](#header-only-usage)
+- [CMake Integration](#cmake-integration)
+  - [FetchContent](#fetchcontent)
+  - [find_package](#find_package)
+- [C++20 Modules](#c20-modules)
+  - [Building with Modules](#building-with-modules)
+  - [Using Modules with FetchContent](#using-modules-with-fetchcontent)
+- [Single Header](#single-header)
+
+## Header-Only Usage
+
+tabulate is a header-only library. Simply add `include/` to your include directories:
+
+```cpp
+#include <tabulate/table.hpp>
+using namespace tabulate;
+
+int main() {
+    Table table;
+    table.add_row({"Name", "Value"});
+    table.add_row({"Hello", "World"});
+    std::cout << table << std::endl;
+}
+```
+
+## CMake Integration
+
+### FetchContent
+
+The recommended way to use tabulate with CMake is via `FetchContent`:
+
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+  tabulate
+  GIT_REPOSITORY https://github.com/p-ranav/tabulate.git
+  GIT_TAG master
+  GIT_SHALLOW TRUE
+  EXCLUDE_FROM_ALL
+)
+
+FetchContent_MakeAvailable(tabulate)
+
+add_executable(my_app main.cpp)
+target_link_libraries(my_app PRIVATE tabulate::tabulate)
+```
+
+### find_package
+
+If you have installed tabulate system-wide:
+
+```cmake
+find_package(tabulate REQUIRED)
+
+add_executable(my_app main.cpp)
+target_link_libraries(my_app PRIVATE tabulate::tabulate)
+```
+
+## C++20 Modules
+
+tabulate provides C++20 module support, allowing you to use `import tabulate;` instead of header includes. The module is built when `USE_CPP20` is enabled.
+
+### Requirements
+
+- CMake 3.28 or higher
+- `USE_CPP20=ON` CMake option
+- C++20 compatible compiler (Clang 16+ recommended)
+- Generator that supports C++20 modules (Ninja or Visual Studio 17.4+)
+
+### Building with Modules
+
+Enable C++20 mode to build the module:
+
+```bash
+cmake -B build -G Ninja -DUSE_CPP20=ON
+cmake --build build
+```
+
+To disable module building while still using C++20, set `TABULATE_BUILD_MODULE=OFF`:
+
+```bash
+cmake -B build -G Ninja -DUSE_CPP20=ON -DTABULATE_BUILD_MODULE=OFF
+```
+
+### Using Modules with FetchContent
+
+Set `USE_CPP20` before calling `FetchContent_MakeAvailable`:
+
+```cmake
+cmake_minimum_required(VERSION 3.28)
+project(my_project CXX)
+
+include(FetchContent)
+
+FetchContent_Declare(
+  tabulate
+  GIT_REPOSITORY https://github.com/p-ranav/tabulate.git
+  GIT_TAG master
+  GIT_SHALLOW TRUE
+  EXCLUDE_FROM_ALL
+)
+
+# Enable C++20 mode before making tabulate available
+set(USE_CPP20 ON CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(tabulate)
+
+add_executable(my_app main.cpp)
+target_link_libraries(my_app PRIVATE tabulate::tabulate_module)
+```
+
+Then in your code:
+
+```cpp
+import tabulate;
+#include <iostream>
+
+int main() {
+    tabulate::Table table;
+    table.add_row({"Name", "Value"});
+    table.add_row({"Hello", "World"});
+    table.format().font_style({tabulate::FontStyle::bold});
+    std::cout << table << std::endl;
+}
+```
+
+**Note**: The C++20 module requires the Ninja generator:
+
+```bash
+cmake -B build -G Ninja
+cmake --build build
+```
+
+### Exported Types
+
+The module exports the following types from the `tabulate` namespace:
+
+- `Table` - Main table class
+- `FontAlign` - Font alignment enum
+- `FontStyle` - Font style enum
+- `Color` - Color enum
+- `Format` - Format settings class
+- `RowStream` - Stream-based row builder
+
+## Single Header
+
+A single header version is available in `single_include/`. Simply copy `single_include/tabulate/table.hpp` to your project:
+
+```cpp
+#include "table.hpp"
+using namespace tabulate;
+
+int main() {
+    Table table;
+    table.add_row({"Single", "Header"});
+    std::cout << table << std::endl;
+}
+```

--- a/include/tabulate/tabulate.cppm
+++ b/include/tabulate/tabulate.cppm
@@ -1,0 +1,54 @@
+/*
+  __        ___.         .__          __
+_/  |______ \_ |__  __ __|  | _____ _/  |_  ____
+\   __\__  \ | __ \|  |  \  | \__  \\   __\/ __ \
+ |  |  / __ \| \_\ \  |  /  |__/ __ \|  | \  ___/
+ |__| (____  /___  /____/|____(____  /__|  \___  >
+           \/    \/                \/          \/
+Table Maker for Modern C++
+https://github.com/p-ranav/tabulate
+
+Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+SPDX-License-Identifier: MIT
+Copyright (c) 2019 Pranav Srinivas Kumar <pranav.srinivas.kumar@gmail.com>.
+
+Permission is hereby  granted, free of charge, to any  person obtaining a copy
+of this software and associated  documentation files (the "Software"), to deal
+in the Software  without restriction, including without  limitation the rights
+to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/// \file tabulate.cppm
+/// \brief C++20 module interface for the tabulate library
+///
+/// This module provides a clean C++20 module interface to the tabulate
+/// library, isolating the textual header includes to avoid conflicts with
+/// C++ module imports.
+
+module;
+
+#include <tabulate/table.hpp>
+
+export module tabulate;
+
+export namespace tabulate {
+using tabulate::Color;
+using tabulate::FontAlign;
+using tabulate::FontStyle;
+using tabulate::Format;
+using tabulate::RowStream;
+using tabulate::Table;
+}  // namespace tabulate


### PR DESCRIPTION
- Add tabulate.cppm module interface file exporting core types
- Extend CMakeLists.txt to conditionally build C++20 module target
- Create USING.md with comprehensive integration guide covering:
  - Header-only usage
  - CMake FetchContent and find_package
  - C++20 modules with detailed examples
  - Single header usage
- Add USE_CPP20 CMake option for C++20 standard support
- Add TABULATE_BUILD_MODULE option to control module building
- Install module files alongside headers
- Update README.md with link to integration guide

The module support requires CMake 3.28+ and is compatible with generators supporting C++20 modules (Ninja, Visual Studio 17.4+).

Tested:
 - Clang 22 on Linux with Ninja.